### PR TITLE
Avoid sending cached results on all but the first scrape

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -77,12 +77,6 @@ func (c *ZFSCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements the prometheus.Collector interface.
 func (c *ZFSCollector) Collect(ch chan<- prometheus.Metric) {
-	select {
-	case <-c.done:
-	default:
-		c.sendCached(ch, make(map[string]struct{}))
-		return
-	}
 	ctx, cancel := context.WithTimeout(context.Background(), c.Deadline)
 	defer cancel()
 
@@ -180,7 +174,6 @@ func (c *ZFSCollector) sendCached(ch chan<- prometheus.Metric, cacheIndex map[st
 func NewZFSCollector(deadline time.Duration, pools []string) (*ZFSCollector, error) {
 	sort.Strings(pools)
 	done := make(chan struct{}, 1)
-	done <- struct{}{}
 	return &ZFSCollector{
 		Deadline:   deadline,
 		Pools:      pools,


### PR DESCRIPTION
v0.0.2 appears to collect results on the very first scrape, then
continues to send these cached results on all subsequent scrapes instead
of re-collecting data.

This can be seen by turning the loglevel to debug, which will display
log output on the first scrape, but generate no further logs on
subsequent scrapes.