### PR TITLE
fix: fix copy and paste errors when accessing dataset properties

### DIFF
--- a/collector/dataset.go
+++ b/collector/dataset.go
@@ -126,7 +126,7 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool *zfs.Zpoo
 			prometheus: prometheus.MustNewConstMetric(
 				c.usedByDatasetBytes.prometheus,
 				prometheus.GaugeValue,
-				float64(dataset.Avail),
+				float64(dataset.Usedbydataset),
 				labels...,
 			),
 		}
@@ -140,7 +140,7 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool *zfs.Zpoo
 			prometheus: prometheus.MustNewConstMetric(
 				c.quotaBytes.prometheus,
 				prometheus.GaugeValue,
-				float64(dataset.Avail),
+				float64(dataset.Quota),
 				labels...,
 			),
 		}
@@ -150,7 +150,7 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool *zfs.Zpoo
 			prometheus: prometheus.MustNewConstMetric(
 				c.volumeSizeBytes.prometheus,
 				prometheus.GaugeValue,
-				float64(dataset.Avail),
+				float64(dataset.Volsize),
 				labels...,
 			),
 		}


### PR DESCRIPTION
It seems there're some copy and paste errors where the prometheus metric and the dataset property don't match.