### PR TITLE
Refactor collector by DRYing code

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -77,3 +77,28 @@ func registerCollector(collector string, isDefaultEnabled bool, factory factoryF
 func expandMetricName(prefix string, context ...string) string {
 	return strings.Join(append(context, prefix), `-`)
 }
+
+func newDesc(subsystem string, metric_name string, help_text string, labels []string) desc {
+	var name = prometheus.BuildFQName(namespace, subsystem, metric_name)
+	return desc{
+		name: name,
+		prometheus: prometheus.NewDesc(
+			name,
+			help_text,
+			labels,
+			nil,
+		),
+	}
+}
+
+func newMetric(metric_desc *desc, value float64, labels []string) metric {
+	return metric{
+		name: expandMetricName(metric_desc.name, labels...),
+		prometheus: prometheus.MustNewConstMetric(
+			metric_desc.prometheus,
+			prometheus.GaugeValue,
+			value,
+			labels...,
+		),
+	}
+}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -91,11 +91,11 @@ func newDesc(subsystem string, metric_name string, help_text string, labels []st
 	}
 }
 
-func newMetric(metric_desc *desc, value float64, labels []string) metric {
+func newGaugeMetric(metricDesc desc, value float64, labels []string) metric {
 	return metric{
-		name: expandMetricName(metric_desc.name, labels...),
+		name: expandMetricName(metricDesc.name, labels...),
 		prometheus: prometheus.MustNewConstMetric(
-			metric_desc.prometheus,
+			metricDesc.prometheus,
 			prometheus.GaugeValue,
 			value,
 			labels...,

--- a/collector/dataset.go
+++ b/collector/dataset.go
@@ -80,26 +80,26 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool *zfs.Zpoo
 	labelValues := []string{dataset.Name, pool.Name, c.kind}
 
 	// Metrics shared by all dataset types.
-	ch <- newMetric(
-		&c.logicalUsedBytes,
+	ch <- newGaugeMetric(
+		c.logicalUsedBytes,
 		float64(dataset.Logicalused),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.referencedBytes,
+	ch <- newGaugeMetric(
+		c.referencedBytes,
 		float64(dataset.Referenced),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.usedBytes,
+	ch <- newGaugeMetric(
+		c.usedBytes,
 		float64(dataset.Used),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.writtenBytes,
+	ch <- newGaugeMetric(
+		c.writtenBytes,
 		float64(dataset.Written),
 		labelValues,
 	)
@@ -107,14 +107,14 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool *zfs.Zpoo
 	// Metrics shared by multiple dataset types.
 	switch c.kind {
 	case zfs.DatasetFilesystem, zfs.DatasetVolume:
-		ch <- newMetric(
-			&c.availableBytes,
+		ch <- newGaugeMetric(
+			c.availableBytes,
 			float64(dataset.Avail),
 			labelValues,
 		)
 
-		ch <- newMetric(
-			&c.usedByDatasetBytes,
+		ch <- newGaugeMetric(
+			c.usedByDatasetBytes,
 			float64(dataset.Usedbydataset),
 			labelValues,
 		)
@@ -123,15 +123,15 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool *zfs.Zpoo
 	// Metrics specific to individual dataset types.
 	switch c.kind {
 	case zfs.DatasetFilesystem:
-		ch <- newMetric(
-			&c.quotaBytes,
+		ch <- newGaugeMetric(
+			c.quotaBytes,
 			float64(dataset.Quota),
 			labelValues,
 		)
 
 	case zfs.DatasetVolume:
-		ch <- newMetric(
-			&c.volumeSizeBytes,
+		ch <- newGaugeMetric(
+			c.volumeSizeBytes,
 			float64(dataset.Volsize),
 			labelValues,
 		)

--- a/collector/pool.go
+++ b/collector/pool.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/mistifyio/go-zfs"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 func init() {
@@ -23,16 +22,20 @@ const (
 )
 
 type poolCollector struct {
-	health               desc
 	allocatedBytes       desc
-	sizeBytes            desc
-	freeBytes            desc
-	fragmentationPercent desc
-	readOnly             desc
-	freeingBytes         desc
-	leakedBytes          desc
 	dedupRatio           desc
+	fragmentationPercent desc
+	freeBytes            desc
+	freeingBytes         desc
+	health               desc
+	leakedBytes          desc
+	readOnly             desc
+	sizeBytes            desc
 }
+
+const poolSubsystem = `pool`
+
+var poolLabels = []string{`pool`}
 
 func (c *poolCollector) update(ch chan<- metric, pools []*zfs.Zpool, excludes regexpCollection) error {
 	for _, pool := range pools {
@@ -45,6 +48,9 @@ func (c *poolCollector) update(ch chan<- metric, pools []*zfs.Zpool, excludes re
 }
 
 func (c *poolCollector) updatePoolMetrics(ch chan<- metric, pool *zfs.Zpool) error {
+	// match with poolLabels
+	labelValues := []string{pool.Name}
+
 	health, err := healthCodeFromString(pool.Health)
 	if err != nil {
 		return err
@@ -55,199 +61,129 @@ func (c *poolCollector) updatePoolMetrics(ch chan<- metric, pool *zfs.Zpool) err
 		readOnly = 1
 	}
 
-	labels := []string{pool.Name}
+	ch <- newMetric(
+		&c.allocatedBytes,
+		float64(pool.Allocated),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.health.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.health.prometheus,
-			prometheus.GaugeValue,
-			float64(health),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.dedupRatio,
+		pool.DedupRatio,
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.allocatedBytes.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.allocatedBytes.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Allocated),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.fragmentationPercent,
+		float64(pool.Fragmentation),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.sizeBytes.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.sizeBytes.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Size),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.freeBytes,
+		float64(pool.Free),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.freeBytes.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.freeBytes.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Free),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.freeingBytes,
+		float64(pool.Freeing),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.fragmentationPercent.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.fragmentationPercent.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Fragmentation),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.health,
+		float64(health),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.readOnly.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.readOnly.prometheus,
-			prometheus.GaugeValue,
-			readOnly,
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.leakedBytes,
+		float64(pool.Leaked),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.freeingBytes.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.freeingBytes.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Freeing),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.readOnly,
+		readOnly,
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.leakedBytes.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.leakedBytes.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Leaked),
-			labels...,
-		),
-	}
-
-	ch <- metric{
-		name: expandMetricName(c.dedupRatio.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.dedupRatio.prometheus,
-			prometheus.GaugeValue,
-			pool.DedupRatio,
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.sizeBytes,
+		float64(pool.Size),
+		labelValues,
+	)
 
 	return nil
 }
 
 func newPoolCollector() (Collector, error) {
-	const subsystem = `pool`
-	var (
-		labels                   = []string{`pool`}
-		healthName               = prometheus.BuildFQName(namespace, subsystem, `health`)
-		allocatedBytesName       = prometheus.BuildFQName(namespace, subsystem, `allocated_bytes`)
-		sizeBytesName            = prometheus.BuildFQName(namespace, subsystem, `size_bytes`)
-		freeBytesName            = prometheus.BuildFQName(namespace, subsystem, `free_bytes`)
-		fragmentationPercentName = prometheus.BuildFQName(namespace, subsystem, `fragmentation_percent`)
-		readOnlyName             = prometheus.BuildFQName(namespace, subsystem, `readonly`)
-		freeingBytesName         = prometheus.BuildFQName(namespace, subsystem, `freeing_bytes`)
-		leakedBytesName          = prometheus.BuildFQName(namespace, subsystem, `leaked_bytes`)
-		dedupRatioName           = prometheus.BuildFQName(namespace, subsystem, `deduplication_ratio`)
-	)
-
 	return &poolCollector{
-		health: desc{
-			name: healthName,
-			prometheus: prometheus.NewDesc(
-				healthName,
-				fmt.Sprintf("Health status code for the pool [%d: %s, %d: %s, %d: %s, %d: %s, %d: %s, %d: %s].",
-					online, zfs.ZpoolOnline, degraded, zfs.ZpoolDegraded, faulted, zfs.ZpoolFaulted, offline, zfs.ZpoolOffline, unavail, zfs.ZpoolUnavail, removed, zfs.ZpoolRemoved),
-				labels,
-				nil,
-			),
-		},
-		allocatedBytes: desc{
-			name: allocatedBytesName,
-			prometheus: prometheus.NewDesc(
-				allocatedBytesName,
-				`Amount of storage space in bytes within the pool that has been physically allocated.`,
-				labels,
-				nil,
-			),
-		},
-		sizeBytes: desc{
-			name: sizeBytesName,
-			prometheus: prometheus.NewDesc(
-				sizeBytesName,
-				`Total size in bytes of the storage pool.`,
-				labels,
-				nil,
-			),
-		},
-		freeBytes: desc{
-			name: freeBytesName,
-			prometheus: prometheus.NewDesc(
-				freeBytesName,
-				`The amount of free space in bytes available in the pool.`,
-				labels,
-				nil,
-			),
-		},
-		fragmentationPercent: desc{
-			name: fragmentationPercentName,
-			prometheus: prometheus.NewDesc(
-				fragmentationPercentName,
-				`Fragmentation percentage of the pool.`,
-				labels,
-				nil,
-			),
-		},
-		readOnly: desc{
-			name: readOnlyName,
-			prometheus: prometheus.NewDesc(
-				readOnlyName,
-				`Read-only status of the pool [0: read-write, 1: read-only].`,
-				labels,
-				nil,
-			),
-		},
-		freeingBytes: desc{
-			name: freeingBytesName,
-			prometheus: prometheus.NewDesc(
-				freeingBytesName,
-				`The amount of space in bytes remaining to be freed following the desctruction of a file system or snapshot.`,
-				labels,
-				nil,
-			),
-		},
-		leakedBytes: desc{
-			name: leakedBytesName,
-			prometheus: prometheus.NewDesc(
-				leakedBytesName,
-				`Number of leaked bytes in the pool.`,
-				labels,
-				nil,
-			),
-		},
-		dedupRatio: desc{
-			name: dedupRatioName,
-			prometheus: prometheus.NewDesc(
-				dedupRatioName,
-				`The deduplication ratio specified for the pool, expressed as a multiplier.`,
-				labels,
-				nil,
-			),
-		},
+
+		allocatedBytes: newDesc(
+			poolSubsystem,
+			`allocated_bytes`,
+			`Amount of storage space in bytes within the pool that has been physically allocated.`,
+			poolLabels,
+		),
+
+		dedupRatio: newDesc(
+			poolSubsystem,
+			`deduplication_ratio`,
+			`The deduplication ratio specified for the pool, expressed as a multiplier.`,
+			poolLabels,
+		),
+
+		fragmentationPercent: newDesc(
+			poolSubsystem,
+			`fragmentation_percent`,
+			`Fragmentation percentage of the pool.`,
+			poolLabels,
+		),
+
+		freeBytes: newDesc(
+			poolSubsystem,
+			`free_bytes`,
+			`The amount of free space in bytes available in the pool.`,
+			poolLabels,
+		),
+
+		freeingBytes: newDesc(
+			poolSubsystem,
+			`freeing_bytes`,
+			`The amount of space in bytes remaining to be freed following the desctruction of a file system or snapshot.`,
+			poolLabels,
+		),
+
+		health: newDesc(
+			poolSubsystem,
+			`health`,
+			fmt.Sprintf("Health status code for the pool [%d: %s, %d: %s, %d: %s, %d: %s, %d: %s, %d: %s].",
+				online, zfs.ZpoolOnline, degraded, zfs.ZpoolDegraded, faulted, zfs.ZpoolFaulted, offline, zfs.ZpoolOffline, unavail, zfs.ZpoolUnavail, removed, zfs.ZpoolRemoved),
+			poolLabels,
+		),
+
+		leakedBytes: newDesc(
+			poolSubsystem,
+			`leaked_bytes`,
+			`Number of leaked bytes in the pool.`,
+			poolLabels,
+		),
+
+		readOnly: newDesc(
+			poolSubsystem,
+			`readonly`,
+			`Read-only status of the pool [0: read-write, 1: read-only].`,
+			poolLabels,
+		),
+
+		sizeBytes: newDesc(
+			poolSubsystem,
+			`size_bytes`,
+			`Total size in bytes of the storage pool.`,
+			poolLabels,
+		),
 	}, nil
 }
 

--- a/collector/pool.go
+++ b/collector/pool.go
@@ -61,56 +61,56 @@ func (c *poolCollector) updatePoolMetrics(ch chan<- metric, pool *zfs.Zpool) err
 		readOnly = 1
 	}
 
-	ch <- newMetric(
-		&c.allocatedBytes,
+	ch <- newGaugeMetric(
+		c.allocatedBytes,
 		float64(pool.Allocated),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.dedupRatio,
+	ch <- newGaugeMetric(
+		c.dedupRatio,
 		pool.DedupRatio,
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.fragmentationPercent,
+	ch <- newGaugeMetric(
+		c.fragmentationPercent,
 		float64(pool.Fragmentation),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.freeBytes,
+	ch <- newGaugeMetric(
+		c.freeBytes,
 		float64(pool.Free),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.freeingBytes,
+	ch <- newGaugeMetric(
+		c.freeingBytes,
 		float64(pool.Freeing),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.health,
+	ch <- newGaugeMetric(
+		c.health,
 		float64(health),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.leakedBytes,
+	ch <- newGaugeMetric(
+		c.leakedBytes,
 		float64(pool.Leaked),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.readOnly,
+	ch <- newGaugeMetric(
+		c.readOnly,
 		readOnly,
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.sizeBytes,
+	ch <- newGaugeMetric(
+		c.sizeBytes,
 		float64(pool.Size),
 		labelValues,
 	)
@@ -120,7 +120,6 @@ func (c *poolCollector) updatePoolMetrics(ch chan<- metric, pool *zfs.Zpool) err
 
 func newPoolCollector() (Collector, error) {
 	return &poolCollector{
-
 		allocatedBytes: newDesc(
 			poolSubsystem,
 			`allocated_bytes`,


### PR DESCRIPTION
I extracted two helper functions to reduce repetition when creating metrics descriptions (i.e. `newDesc()`) as well as metrics data points themselves (i.e. `newMetric()`) ... they're named after the data structures they return (no creative reinterpretation there). :smile: 

Also I tried to sort metrics (alphabetically) where possible. Otherwise it's difficult to keep track of them. :sweat_smile: 