### PR TITLE
Redo ZFS CLI parsing

### DIFF
--- a/basic_zfs/zfs.go
+++ b/basic_zfs/zfs.go
@@ -21,10 +21,13 @@ func DatasetProperties(pool string, dsType string, dsProperties []string) ([][]s
 	}
 
 	output := string(outBytes)
-	lines := strings.Split(output, "\n") // NOTE: last line is empty
-	results := make([][]string, len(lines)-1)
-	for i, line := range lines[:len(lines)-1] {
-		results[i] = strings.Fields(line)
+	lines := strings.Split(output, "\n")
+	results := make([][]string, 0, len(lines))
+	for _, line := range lines {
+		// NOTE: last line is empty
+		if len(line) > 0 {
+			results = append(results, strings.Fields(line))
+		}
 	}
 	return results, nil
 }

--- a/basic_zfs/zfs.go
+++ b/basic_zfs/zfs.go
@@ -1,0 +1,42 @@
+package basic_zfs
+
+import (
+	"os/exec"
+	"strings"
+)
+
+const (
+	DatasetFilesystem = "filesystem"
+	DatasetSnapshot   = "snapshot"
+	DatasetVolume     = "volume"
+)
+
+func DatasetProperties(pool string, dsType string, dsProperties []string) ([][]string, error) {
+	joinedDsProps := strings.Join(dsProperties, ",")
+	outBytes, err := exec.Command(
+		"zfs", "list", "-Hprt", dsType, "-o", joinedDsProps, pool,
+	).Output()
+	if err != nil {
+		return nil, err
+	}
+
+	output := string(outBytes)
+	lines := strings.Split(output, "\n") // NOTE: last line is empty
+	results := make([][]string, len(lines)-1)
+	for i, line := range lines[:len(lines)-1] {
+		results[i] = strings.Fields(line)
+	}
+	return results, nil
+}
+
+func FilesystemProperties(pool string, properties []string) ([][]string, error) {
+	return DatasetProperties(pool, DatasetFilesystem, properties)
+}
+
+func SnapshotProperties(pool string, properties []string) ([][]string, error) {
+	return DatasetProperties(pool, DatasetSnapshot, properties)
+}
+
+func VolumeProperties(pool string, properties []string) ([][]string, error) {
+	return DatasetProperties(pool, DatasetVolume, properties)
+}

--- a/basic_zfs/zpool.go
+++ b/basic_zfs/zpool.go
@@ -5,6 +5,15 @@ import (
 	"strings"
 )
 
+const (
+	ZpoolOnline   = "ONLINE"
+	ZpoolDegraded = "DEGRADED"
+	ZpoolFaulted  = "FAULTED"
+	ZpoolOffline  = "OFFLINE"
+	ZpoolUnavail  = "UNAVAIL"
+	ZpoolRemoved  = "REMOVED"
+)
+
 func ListPools() ([]string, error) {
 	out, err := exec.Command("zpool", "list", "-Hpo", "name").Output()
 	if err != nil {

--- a/basic_zfs/zpool.go
+++ b/basic_zfs/zpool.go
@@ -14,3 +14,24 @@ func ListPools() ([]string, error) {
 	output := string(out[:])
 	return strings.Fields(output), nil
 }
+
+func PoolProperties(pools []string, poolProperties []string) ([][]string, error) {
+	joinedDsProps := strings.Join(poolProperties, ",")
+	zpoolArgs := []string{"list", "-Hpo", joinedDsProps}
+	zpoolArgs = append(zpoolArgs, pools...)
+	outBytes, err := exec.Command("zpool", zpoolArgs...).Output()
+	if err != nil {
+		return nil, err
+	}
+
+	output := string(outBytes)
+	lines := strings.Split(output, "\n")
+	results := make([][]string, 0, len(lines))
+	for _, line := range lines {
+		// NOTE: last line is empty
+		if len(line) > 0 {
+			results = append(results, strings.Fields(line))
+		}
+	}
+	return results, nil
+}

--- a/basic_zfs/zpool.go
+++ b/basic_zfs/zpool.go
@@ -1,0 +1,16 @@
+package basic_zfs
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func ListPools() ([]string, error) {
+	out, err := exec.Command("zpool", "list", "-Hpo", "name").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	output := string(out[:])
+	return strings.Fields(output), nil
+}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -77,3 +77,28 @@ func registerCollector(collector string, isDefaultEnabled bool, factory factoryF
 func expandMetricName(prefix string, context ...string) string {
 	return strings.Join(append(context, prefix), `-`)
 }
+
+func newDesc(subsystem string, metric_name string, help_text string, labels []string) desc {
+	var name = prometheus.BuildFQName(namespace, subsystem, metric_name)
+	return desc{
+		name: name,
+		prometheus: prometheus.NewDesc(
+			name,
+			help_text,
+			labels,
+			nil,
+		),
+	}
+}
+
+func newMetric(metric_desc *desc, value float64, labels []string) metric {
+	return metric{
+		name: expandMetricName(metric_desc.name, labels...),
+		prometheus: prometheus.MustNewConstMetric(
+			metric_desc.prometheus,
+			prometheus.GaugeValue,
+			value,
+			labels...,
+		),
+	}
+}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -91,11 +91,11 @@ func newDesc(subsystem string, metric_name string, help_text string, labels []st
 	}
 }
 
-func newMetric(metric_desc *desc, value float64, labels []string) metric {
+func newGaugeMetric(metricDesc desc, value float64, labels []string) metric {
 	return metric{
-		name: expandMetricName(metric_desc.name, labels...),
+		name: expandMetricName(metricDesc.name, labels...),
 		prometheus: prometheus.MustNewConstMetric(
-			metric_desc.prometheus,
+			metricDesc.prometheus,
 			prometheus.GaugeValue,
 			value,
 			labels...,

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mistifyio/go-zfs"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -43,7 +42,7 @@ type State struct {
 }
 
 type Collector interface {
-	update(ch chan<- metric, pools []*zfs.Zpool, excludes regexpCollection) error
+	update(ch chan<- metric, pools []string, excludes regexpCollection) error
 }
 
 type metric struct {

--- a/collector/conversion.go
+++ b/collector/conversion.go
@@ -1,0 +1,53 @@
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/pdf/zfs_exporter/basic_zfs"
+)
+
+var PropertyConversionError = errors.New("converting property failed")
+
+func float64FromBoolProp(propValue string) (float64, error) {
+	switch propValue {
+	case "on", "yes":
+		return 1, nil
+	case "off", "no":
+		return 0, nil
+	}
+
+	return 0, fmt.Errorf("converting %s to bool: %w", propValue, PropertyConversionError)
+}
+
+func float64FromNumProp(dsPropValue string) float64 {
+	var v float64
+	if dsPropValue != "-" && dsPropValue != "none" {
+		var err error
+		v, err = strconv.ParseFloat(dsPropValue, 64)
+		if err != nil {
+			return 0
+		}
+	}
+	return v
+}
+
+func healthCodeFromString(status string) (healthCode, error) {
+	switch status {
+	case basic_zfs.ZpoolOnline:
+		return online, nil
+	case basic_zfs.ZpoolDegraded:
+		return degraded, nil
+	case basic_zfs.ZpoolFaulted:
+		return faulted, nil
+	case basic_zfs.ZpoolOffline:
+		return offline, nil
+	case basic_zfs.ZpoolUnavail:
+		return unavail, nil
+	case basic_zfs.ZpoolRemoved:
+		return removed, nil
+	}
+
+	return -1, fmt.Errorf(`unknown pool heath status: %s`, status)
+}

--- a/collector/dataset.go
+++ b/collector/dataset.go
@@ -80,26 +80,26 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool *zfs.Zpoo
 	labelValues := []string{dataset.Name, pool.Name, c.kind}
 
 	// Metrics shared by all dataset types.
-	ch <- newMetric(
-		&c.logicalUsedBytes,
+	ch <- newGaugeMetric(
+		c.logicalUsedBytes,
 		float64(dataset.Logicalused),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.referencedBytes,
+	ch <- newGaugeMetric(
+		c.referencedBytes,
 		float64(dataset.Referenced),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.usedBytes,
+	ch <- newGaugeMetric(
+		c.usedBytes,
 		float64(dataset.Used),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.writtenBytes,
+	ch <- newGaugeMetric(
+		c.writtenBytes,
 		float64(dataset.Written),
 		labelValues,
 	)
@@ -107,14 +107,14 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool *zfs.Zpoo
 	// Metrics shared by multiple dataset types.
 	switch c.kind {
 	case zfs.DatasetFilesystem, zfs.DatasetVolume:
-		ch <- newMetric(
-			&c.availableBytes,
+		ch <- newGaugeMetric(
+			c.availableBytes,
 			float64(dataset.Avail),
 			labelValues,
 		)
 
-		ch <- newMetric(
-			&c.usedByDatasetBytes,
+		ch <- newGaugeMetric(
+			c.usedByDatasetBytes,
 			float64(dataset.Usedbydataset),
 			labelValues,
 		)
@@ -123,15 +123,15 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool *zfs.Zpoo
 	// Metrics specific to individual dataset types.
 	switch c.kind {
 	case zfs.DatasetFilesystem:
-		ch <- newMetric(
-			&c.quotaBytes,
+		ch <- newGaugeMetric(
+			c.quotaBytes,
 			float64(dataset.Quota),
 			labelValues,
 		)
 
 	case zfs.DatasetVolume:
-		ch <- newMetric(
-			&c.volumeSizeBytes,
+		ch <- newGaugeMetric(
+			c.volumeSizeBytes,
 			float64(dataset.Volsize),
 			labelValues,
 		)

--- a/collector/dataset.go
+++ b/collector/dataset.go
@@ -12,7 +12,25 @@ func init() {
 	registerCollector(`dataset-volume`, defaultEnabled, newVolumeCollector)
 }
 
-const datasetSubsystem = `dataset`
+type datasetCollector struct {
+	kind string
+	// all datasets
+	logicalReferencedBytes desc
+	logicalUsedBytes       desc
+	referencedBytes        desc
+	usedBytes              desc
+	writtenBytes           desc
+	// volumes and filesystems only (i.e. no snapshots)
+	availableBytes            desc
+	usedByChildrenBytes       desc
+	usedByDatasetBytes        desc
+	usedByRefreservationBytes desc
+	usedBySnapshotsBytes      desc
+	// filesystems only
+	quotaBytes desc
+	// volumes only
+	volumeSizeBytes desc
+}
 
 var datasetLabels = []string{
 	`name`,
@@ -40,25 +58,7 @@ var datasetProperties = []string{
 	"volsize",
 }
 
-type datasetCollector struct {
-	kind string
-	// all datasets
-	logicalReferencedBytes desc
-	logicalUsedBytes       desc
-	referencedBytes        desc
-	usedBytes              desc
-	writtenBytes           desc
-	// volumes and filesystems only (i.e. no snapshots)
-	availableBytes            desc
-	usedByChildrenBytes       desc
-	usedByDatasetBytes        desc
-	usedByRefreservationBytes desc
-	usedBySnapshotsBytes      desc
-	// filesystems only
-	quotaBytes desc
-	// volumes only
-	volumeSizeBytes desc
-}
+const datasetSubsystem = `dataset`
 
 func (c *datasetCollector) update(ch chan<- metric, pools []string, excludes regexpCollection) error {
 	for _, pool := range pools {

--- a/collector/dataset.go
+++ b/collector/dataset.go
@@ -2,8 +2,6 @@ package collector
 
 import (
 	"fmt"
-	"log"
-	"strconv"
 
 	"github.com/pdf/zfs_exporter/basic_zfs"
 )
@@ -62,19 +60,6 @@ type datasetCollector struct {
 	volumeSizeBytes desc
 }
 
-func (c *datasetCollector) toFloat64(dsPropValue string) float64 {
-	var v float64
-	if dsPropValue != "-" && dsPropValue != "none" {
-		var err error
-		v, err = strconv.ParseFloat(dsPropValue, 64)
-		if err != nil {
-			log.Fatalln(err)
-			return 0
-		}
-	}
-	return v
-}
-
 func (c *datasetCollector) update(ch chan<- metric, pools []string, excludes regexpCollection) error {
 	for _, pool := range pools {
 		if err := c.updatePoolMetrics(ch, pool, excludes); err != nil {
@@ -123,31 +108,31 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool string, d
 	// Metrics shared by all dataset types.
 	ch <- newGaugeMetric(
 		c.logicalReferencedBytes,
-		c.toFloat64(dsProps[1]),
+		float64FromNumProp(dsProps[1]),
 		labelValues,
 	)
 
 	ch <- newGaugeMetric(
 		c.logicalUsedBytes,
-		c.toFloat64(dsProps[2]),
+		float64FromNumProp(dsProps[2]),
 		labelValues,
 	)
 
 	ch <- newGaugeMetric(
 		c.referencedBytes,
-		c.toFloat64(dsProps[3]),
+		float64FromNumProp(dsProps[3]),
 		labelValues,
 	)
 
 	ch <- newGaugeMetric(
 		c.usedBytes,
-		c.toFloat64(dsProps[4]),
+		float64FromNumProp(dsProps[4]),
 		labelValues,
 	)
 
 	ch <- newGaugeMetric(
 		c.writtenBytes,
-		c.toFloat64(dsProps[5]),
+		float64FromNumProp(dsProps[5]),
 		labelValues,
 	)
 
@@ -156,31 +141,31 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool string, d
 	case basic_zfs.DatasetFilesystem, basic_zfs.DatasetVolume:
 		ch <- newGaugeMetric(
 			c.availableBytes,
-			c.toFloat64(dsProps[6]),
+			float64FromNumProp(dsProps[6]),
 			labelValues,
 		)
 
 		ch <- newGaugeMetric(
 			c.usedByChildrenBytes,
-			c.toFloat64(dsProps[7]),
+			float64FromNumProp(dsProps[7]),
 			labelValues,
 		)
 
 		ch <- newGaugeMetric(
 			c.usedByDatasetBytes,
-			c.toFloat64(dsProps[8]),
+			float64FromNumProp(dsProps[8]),
 			labelValues,
 		)
 
 		ch <- newGaugeMetric(
 			c.usedByRefreservationBytes,
-			c.toFloat64(dsProps[9]),
+			float64FromNumProp(dsProps[9]),
 			labelValues,
 		)
 
 		ch <- newGaugeMetric(
 			c.usedBySnapshotsBytes,
-			c.toFloat64(dsProps[10]),
+			float64FromNumProp(dsProps[10]),
 			labelValues,
 		)
 	}
@@ -190,14 +175,14 @@ func (c *datasetCollector) updateDatasetMetrics(ch chan<- metric, pool string, d
 	case basic_zfs.DatasetFilesystem:
 		ch <- newGaugeMetric(
 			c.quotaBytes,
-			c.toFloat64(dsProps[11]),
+			float64FromNumProp(dsProps[11]),
 			labelValues,
 		)
 
 	case basic_zfs.DatasetVolume:
 		ch <- newGaugeMetric(
 			c.volumeSizeBytes,
-			c.toFloat64(dsProps[12]),
+			float64FromNumProp(dsProps[12]),
 			labelValues,
 		)
 	}

--- a/collector/pool.go
+++ b/collector/pool.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/mistifyio/go-zfs"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 func init() {
@@ -23,16 +22,20 @@ const (
 )
 
 type poolCollector struct {
-	health               desc
 	allocatedBytes       desc
-	sizeBytes            desc
-	freeBytes            desc
-	fragmentationPercent desc
-	readOnly             desc
-	freeingBytes         desc
-	leakedBytes          desc
 	dedupRatio           desc
+	fragmentationPercent desc
+	freeBytes            desc
+	freeingBytes         desc
+	health               desc
+	leakedBytes          desc
+	readOnly             desc
+	sizeBytes            desc
 }
+
+const poolSubsystem = `pool`
+
+var poolLabels = []string{`pool`}
 
 func (c *poolCollector) update(ch chan<- metric, pools []*zfs.Zpool, excludes regexpCollection) error {
 	for _, pool := range pools {
@@ -45,6 +48,9 @@ func (c *poolCollector) update(ch chan<- metric, pools []*zfs.Zpool, excludes re
 }
 
 func (c *poolCollector) updatePoolMetrics(ch chan<- metric, pool *zfs.Zpool) error {
+	// match with poolLabels
+	labelValues := []string{pool.Name}
+
 	health, err := healthCodeFromString(pool.Health)
 	if err != nil {
 		return err
@@ -55,199 +61,129 @@ func (c *poolCollector) updatePoolMetrics(ch chan<- metric, pool *zfs.Zpool) err
 		readOnly = 1
 	}
 
-	labels := []string{pool.Name}
+	ch <- newMetric(
+		&c.allocatedBytes,
+		float64(pool.Allocated),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.health.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.health.prometheus,
-			prometheus.GaugeValue,
-			float64(health),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.dedupRatio,
+		pool.DedupRatio,
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.allocatedBytes.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.allocatedBytes.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Allocated),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.fragmentationPercent,
+		float64(pool.Fragmentation),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.sizeBytes.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.sizeBytes.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Size),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.freeBytes,
+		float64(pool.Free),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.freeBytes.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.freeBytes.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Free),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.freeingBytes,
+		float64(pool.Freeing),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.fragmentationPercent.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.fragmentationPercent.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Fragmentation),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.health,
+		float64(health),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.readOnly.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.readOnly.prometheus,
-			prometheus.GaugeValue,
-			readOnly,
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.leakedBytes,
+		float64(pool.Leaked),
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.freeingBytes.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.freeingBytes.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Freeing),
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.readOnly,
+		readOnly,
+		labelValues,
+	)
 
-	ch <- metric{
-		name: expandMetricName(c.leakedBytes.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.leakedBytes.prometheus,
-			prometheus.GaugeValue,
-			float64(pool.Leaked),
-			labels...,
-		),
-	}
-
-	ch <- metric{
-		name: expandMetricName(c.dedupRatio.name, labels...),
-		prometheus: prometheus.MustNewConstMetric(
-			c.dedupRatio.prometheus,
-			prometheus.GaugeValue,
-			pool.DedupRatio,
-			labels...,
-		),
-	}
+	ch <- newMetric(
+		&c.sizeBytes,
+		float64(pool.Size),
+		labelValues,
+	)
 
 	return nil
 }
 
 func newPoolCollector() (Collector, error) {
-	const subsystem = `pool`
-	var (
-		labels                   = []string{`pool`}
-		healthName               = prometheus.BuildFQName(namespace, subsystem, `health`)
-		allocatedBytesName       = prometheus.BuildFQName(namespace, subsystem, `allocated_bytes`)
-		sizeBytesName            = prometheus.BuildFQName(namespace, subsystem, `size_bytes`)
-		freeBytesName            = prometheus.BuildFQName(namespace, subsystem, `free_bytes`)
-		fragmentationPercentName = prometheus.BuildFQName(namespace, subsystem, `fragmentation_percent`)
-		readOnlyName             = prometheus.BuildFQName(namespace, subsystem, `readonly`)
-		freeingBytesName         = prometheus.BuildFQName(namespace, subsystem, `freeing_bytes`)
-		leakedBytesName          = prometheus.BuildFQName(namespace, subsystem, `leaked_bytes`)
-		dedupRatioName           = prometheus.BuildFQName(namespace, subsystem, `deduplication_ratio`)
-	)
-
 	return &poolCollector{
-		health: desc{
-			name: healthName,
-			prometheus: prometheus.NewDesc(
-				healthName,
-				fmt.Sprintf("Health status code for the pool [%d: %s, %d: %s, %d: %s, %d: %s, %d: %s, %d: %s].",
-					online, zfs.ZpoolOnline, degraded, zfs.ZpoolDegraded, faulted, zfs.ZpoolFaulted, offline, zfs.ZpoolOffline, unavail, zfs.ZpoolUnavail, removed, zfs.ZpoolRemoved),
-				labels,
-				nil,
-			),
-		},
-		allocatedBytes: desc{
-			name: allocatedBytesName,
-			prometheus: prometheus.NewDesc(
-				allocatedBytesName,
-				`Amount of storage space in bytes within the pool that has been physically allocated.`,
-				labels,
-				nil,
-			),
-		},
-		sizeBytes: desc{
-			name: sizeBytesName,
-			prometheus: prometheus.NewDesc(
-				sizeBytesName,
-				`Total size in bytes of the storage pool.`,
-				labels,
-				nil,
-			),
-		},
-		freeBytes: desc{
-			name: freeBytesName,
-			prometheus: prometheus.NewDesc(
-				freeBytesName,
-				`The amount of free space in bytes available in the pool.`,
-				labels,
-				nil,
-			),
-		},
-		fragmentationPercent: desc{
-			name: fragmentationPercentName,
-			prometheus: prometheus.NewDesc(
-				fragmentationPercentName,
-				`Fragmentation percentage of the pool.`,
-				labels,
-				nil,
-			),
-		},
-		readOnly: desc{
-			name: readOnlyName,
-			prometheus: prometheus.NewDesc(
-				readOnlyName,
-				`Read-only status of the pool [0: read-write, 1: read-only].`,
-				labels,
-				nil,
-			),
-		},
-		freeingBytes: desc{
-			name: freeingBytesName,
-			prometheus: prometheus.NewDesc(
-				freeingBytesName,
-				`The amount of space in bytes remaining to be freed following the desctruction of a file system or snapshot.`,
-				labels,
-				nil,
-			),
-		},
-		leakedBytes: desc{
-			name: leakedBytesName,
-			prometheus: prometheus.NewDesc(
-				leakedBytesName,
-				`Number of leaked bytes in the pool.`,
-				labels,
-				nil,
-			),
-		},
-		dedupRatio: desc{
-			name: dedupRatioName,
-			prometheus: prometheus.NewDesc(
-				dedupRatioName,
-				`The deduplication ratio specified for the pool, expressed as a multiplier.`,
-				labels,
-				nil,
-			),
-		},
+
+		allocatedBytes: newDesc(
+			poolSubsystem,
+			`allocated_bytes`,
+			`Amount of storage space in bytes within the pool that has been physically allocated.`,
+			poolLabels,
+		),
+
+		dedupRatio: newDesc(
+			poolSubsystem,
+			`deduplication_ratio`,
+			`The deduplication ratio specified for the pool, expressed as a multiplier.`,
+			poolLabels,
+		),
+
+		fragmentationPercent: newDesc(
+			poolSubsystem,
+			`fragmentation_percent`,
+			`Fragmentation percentage of the pool.`,
+			poolLabels,
+		),
+
+		freeBytes: newDesc(
+			poolSubsystem,
+			`free_bytes`,
+			`The amount of free space in bytes available in the pool.`,
+			poolLabels,
+		),
+
+		freeingBytes: newDesc(
+			poolSubsystem,
+			`freeing_bytes`,
+			`The amount of space in bytes remaining to be freed following the desctruction of a file system or snapshot.`,
+			poolLabels,
+		),
+
+		health: newDesc(
+			poolSubsystem,
+			`health`,
+			fmt.Sprintf("Health status code for the pool [%d: %s, %d: %s, %d: %s, %d: %s, %d: %s, %d: %s].",
+				online, zfs.ZpoolOnline, degraded, zfs.ZpoolDegraded, faulted, zfs.ZpoolFaulted, offline, zfs.ZpoolOffline, unavail, zfs.ZpoolUnavail, removed, zfs.ZpoolRemoved),
+			poolLabels,
+		),
+
+		leakedBytes: newDesc(
+			poolSubsystem,
+			`leaked_bytes`,
+			`Number of leaked bytes in the pool.`,
+			poolLabels,
+		),
+
+		readOnly: newDesc(
+			poolSubsystem,
+			`readonly`,
+			`Read-only status of the pool [0: read-write, 1: read-only].`,
+			poolLabels,
+		),
+
+		sizeBytes: newDesc(
+			poolSubsystem,
+			`size_bytes`,
+			`Total size in bytes of the storage pool.`,
+			poolLabels,
+		),
 	}, nil
 }
 

--- a/collector/pool.go
+++ b/collector/pool.go
@@ -189,22 +189,3 @@ func newPoolCollector() (Collector, error) {
 		),
 	}, nil
 }
-
-func healthCodeFromString(status string) (healthCode, error) {
-	switch status {
-	case zfs.ZpoolOnline:
-		return online, nil
-	case zfs.ZpoolDegraded:
-		return degraded, nil
-	case zfs.ZpoolFaulted:
-		return faulted, nil
-	case zfs.ZpoolOffline:
-		return offline, nil
-	case zfs.ZpoolUnavail:
-		return unavail, nil
-	case zfs.ZpoolRemoved:
-		return removed, nil
-	}
-
-	return -1, fmt.Errorf(`unknown pool heath status: %s`, status)
-}

--- a/collector/pool.go
+++ b/collector/pool.go
@@ -61,56 +61,56 @@ func (c *poolCollector) updatePoolMetrics(ch chan<- metric, pool *zfs.Zpool) err
 		readOnly = 1
 	}
 
-	ch <- newMetric(
-		&c.allocatedBytes,
+	ch <- newGaugeMetric(
+		c.allocatedBytes,
 		float64(pool.Allocated),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.dedupRatio,
+	ch <- newGaugeMetric(
+		c.dedupRatio,
 		pool.DedupRatio,
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.fragmentationPercent,
+	ch <- newGaugeMetric(
+		c.fragmentationPercent,
 		float64(pool.Fragmentation),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.freeBytes,
+	ch <- newGaugeMetric(
+		c.freeBytes,
 		float64(pool.Free),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.freeingBytes,
+	ch <- newGaugeMetric(
+		c.freeingBytes,
 		float64(pool.Freeing),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.health,
+	ch <- newGaugeMetric(
+		c.health,
 		float64(health),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.leakedBytes,
+	ch <- newGaugeMetric(
+		c.leakedBytes,
 		float64(pool.Leaked),
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.readOnly,
+	ch <- newGaugeMetric(
+		c.readOnly,
 		readOnly,
 		labelValues,
 	)
 
-	ch <- newMetric(
-		&c.sizeBytes,
+	ch <- newGaugeMetric(
+		c.sizeBytes,
 		float64(pool.Size),
 		labelValues,
 	)
@@ -120,7 +120,6 @@ func (c *poolCollector) updatePoolMetrics(ch chan<- metric, pool *zfs.Zpool) err
 
 func newPoolCollector() (Collector, error) {
 	return &poolCollector{
-
 		allocatedBytes: newDesc(
 			poolSubsystem,
 			`allocated_bytes`,

--- a/collector/pool.go
+++ b/collector/pool.go
@@ -37,9 +37,13 @@ const poolSubsystem = `pool`
 
 var poolLabels = []string{`pool`}
 
-func (c *poolCollector) update(ch chan<- metric, pools []*zfs.Zpool, excludes regexpCollection) error {
+func (c *poolCollector) update(ch chan<- metric, pools []string, excludes regexpCollection) error {
 	for _, pool := range pools {
-		if err := c.updatePoolMetrics(ch, pool); err != nil {
+		zpool, err := zfs.GetZpool(pool)
+		if err != nil {
+			return err
+		}
+		if err := c.updatePoolMetrics(ch, zpool); err != nil {
 			return err
 		}
 	}

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/mistifyio/go-zfs"
+	"github.com/pdf/zfs_exporter/basic_zfs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -153,31 +153,20 @@ func (c *ZFS) sendCached(ch chan<- prometheus.Metric, cacheIndex map[string]stru
 	}
 }
 
-func (c *ZFS) getPools(pools []string) ([]*zfs.Zpool, error) {
+func (c *ZFS) getPools(pools []string) ([]string, error) {
 	// Get all pools if not explicitly configured.
 	if len(pools) == 0 {
-		zpools, err := zfs.ListZpools()
+		pools, err := basic_zfs.ListPools()
 		if err != nil {
 			return nil, err
 		}
-		return zpools, nil
+		return pools, nil
 	}
 
-	// Configured pools may not exist, so append available pools as they're found, rather than allocating up front.
-	zpools := make([]*zfs.Zpool, 0)
-	for _, name := range pools {
-		pool, err := zfs.GetZpool(name)
-		if err != nil {
-			_ = level.Warn(c.logger).Log("msg", "Pool unavailable", "pool", name)
-			continue
-		}
-		zpools = append(zpools, pool)
-	}
-
-	return zpools, nil
+	return pools, nil
 }
 
-func (c *ZFS) execute(ctx context.Context, name string, collector Collector, ch chan<- metric, pools []*zfs.Zpool) {
+func (c *ZFS) execute(ctx context.Context, name string, collector Collector, ch chan<- metric, pools []string) {
 	begin := time.Now()
 	err := collector.update(ch, pools, c.excludes)
 	duration := time.Since(begin)

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,6 @@ require (
 	github.com/go-kit/kit v0.10.0
 	github.com/go-kit/log v0.1.0
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/uuid v1.2.0 // indirect
-	github.com/mistifyio/go-zfs v2.1.2-0.20180321011823-d5b163290a48+incompatible
-	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.29.0
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,6 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
-github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -239,8 +237,6 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/mistifyio/go-zfs v2.1.2-0.20180321011823-d5b163290a48+incompatible h1:ykF7RTauaW3BBWZPcJz4dPU5aZCbi6SQiKhIl3WxdUs=
-github.com/mistifyio/go-zfs v2.1.2-0.20180321011823-d5b163290a48+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
@@ -279,8 +275,6 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
-github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
-github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=


### PR DESCRIPTION
This is basically a rewrite of the pieces interacting with the ZFS CLI. The interface we require is **very** minimal: 3 functions and a few constants. :smile:
This code is currently based on #9 ... if you'd like I could rebase it onto master. :sweat_smile: 

* completely replaces [mistifyio/go-zfs](https://github.com/mistifyio/go-zfs).
* it's trivial to add more properties now (there're already some more dataset properties)
* less conversion steps

Trade-offs:
* uses `[]string` and `[][]string` for pool and dataset properties instead of "nicer" `zfs.Zpool` and `zfs.Dataset` structs
  * the order (i.e. index) of results is coupled to the order of property names in e.g. [`datasetProperties`](https://github.com/pdf/zfs_exporter/compare/master...riyad:redo-zfs-cli-parsing?expand=1#diff-3bf2452db116a1ea6ba41449c03c0a547371ab4fca7f49951730c03ae41abad8R41)
    * OK when you realize that you have to touch two pieces of code for any change to the properties anyway (i.e. list of properties, updating metrics) ... it's just indices instead of struct fields :shrug:
 
Questions:
* What is the purpose of `ZFS.getPools()` exactly? Is it superfluous now? It seems it's still needed in case there were no specific pools given to monitor, am I right?
* should the new `basic_zfs` package be renamed to something like `zfs` or `zfs_cli`? :shrug:

I hope this goes more into the direction you were thinking of. :wink: 

Fixes #7