### PR TITLE
fix(build): update go module version to match release tag major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,17 @@ Prometheus exporter for ZFS (pools, filesystems, snapshots and volumes). Other i
 
 Download the [latest release](https://github.com/pdf/zfs_exporter/releases/latest) for your platform, and unpack it somewhere on your filesystem.
 
-You may also build the latest version using Go v1.11+ via `go get`:
+You may also build the latest version using Go v1.11 - 1.17 via `go get`:
 
 ```bash
 go get -u github.com/pdf/zfs_exporter
+```
+
+Installation can also be accomplished using `go install`:
+
+```bash
+version=latest # or a specific version tag
+go install github.com/pdf/zfs_exporter@$version
 ```
 
 ## Usage

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-kit/log"
-	"github.com/pdf/zfs_exporter/zfs"
+	"github.com/pdf/zfs_exporter/v2/zfs"
 	"github.com/prometheus/client_golang/prometheus"
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/pdf/zfs_exporter/zfs"
+	"github.com/pdf/zfs_exporter/v2/zfs"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )

--- a/collector/dataset.go
+++ b/collector/dataset.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pdf/zfs_exporter/zfs"
+	"github.com/pdf/zfs_exporter/v2/zfs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/dataset_test.go
+++ b/collector/dataset_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/pdf/zfs_exporter/zfs"
-	"github.com/pdf/zfs_exporter/zfs/mock_zfs"
+	"github.com/pdf/zfs_exporter/v2/zfs"
+	"github.com/pdf/zfs_exporter/v2/zfs/mock_zfs"
 )
 
 type datasetResults struct {

--- a/collector/pool.go
+++ b/collector/pool.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pdf/zfs_exporter/zfs"
+	"github.com/pdf/zfs_exporter/v2/zfs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/pool_test.go
+++ b/collector/pool_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/pdf/zfs_exporter/zfs/mock_zfs"
+	"github.com/pdf/zfs_exporter/v2/zfs/mock_zfs"
 )
 
 func TestPoolMetrics(t *testing.T) {

--- a/collector/transform.go
+++ b/collector/transform.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/pdf/zfs_exporter/zfs"
+	"github.com/pdf/zfs_exporter/v2/zfs"
 )
 
 type poolHealthCode int

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/pdf/zfs_exporter/zfs"
+	"github.com/pdf/zfs_exporter/v2/zfs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pdf/zfs_exporter
+module github.com/pdf/zfs_exporter/v2
 
 go 1.17
 

--- a/zfs/mock_zfs/mock_zfs.go
+++ b/zfs/mock_zfs/mock_zfs.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	zfs "github.com/pdf/zfs_exporter/zfs"
+	zfs "github.com/pdf/zfs_exporter/v2/zfs"
 )
 
 // MockClient is a mock of Client interface.

--- a/zfs_exporter.go
+++ b/zfs_exporter.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pdf/zfs_exporter/collector"
-	"github.com/pdf/zfs_exporter/zfs"
+	"github.com/pdf/zfs_exporter/v2/collector"
+	"github.com/pdf/zfs_exporter/v2/zfs"
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"


### PR DESCRIPTION
Updates the go module version to adhere to the official guidance in https://go.dev/ref/mod#major-version-suffixes.

Fixes https://github.com/pdf/zfs_exporter/issues/15