### PR TITLE
[POC] parse JSON output of ZFS commands

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -3,7 +3,7 @@ go:
   # .circle/config.yml should also be updated.
   version: 1.23
 repository:
-  path: github.com/pdf/zfs_exporter/v2
+  path: github.com/jmcgover/zfs_exporter/v2
 build:
   flags: -a -tags netgo
   ldflags: |

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/pdf/zfs_exporter/v2/zfs"
+	"github.com/jmcgover/zfs_exporter/v2/zfs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/pdf/zfs_exporter/v2/zfs"
+	"github.com/jmcgover/zfs_exporter/v2/zfs"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )

--- a/collector/dataset.go
+++ b/collector/dataset.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/pdf/zfs_exporter/v2/zfs"
+	"github.com/jmcgover/zfs_exporter/v2/zfs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/dataset_test.go
+++ b/collector/dataset_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pdf/zfs_exporter/v2/zfs"
-	"github.com/pdf/zfs_exporter/v2/zfs/mock_zfs"
+	"github.com/jmcgover/zfs_exporter/v2/zfs"
+	"github.com/jmcgover/zfs_exporter/v2/zfs/mock_zfs"
 	"go.uber.org/mock/gomock"
 )
 

--- a/collector/pool.go
+++ b/collector/pool.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"sync"
 
-	"github.com/pdf/zfs_exporter/v2/zfs"
+	"github.com/jmcgover/zfs_exporter/v2/zfs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/pool_test.go
+++ b/collector/pool_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pdf/zfs_exporter/v2/zfs/mock_zfs"
+	"github.com/jmcgover/zfs_exporter/v2/zfs/mock_zfs"
 	"go.uber.org/mock/gomock"
 )
 
@@ -161,7 +161,7 @@ zfs_pool_health{pool="suspendedpool"} 6
 					`unsupported`: `1024`,
 				},
 			},
-			metricResults: `# HELP zfs_pool_unsupported !!! This property is unsupported, results are likely to be undesirable, please file an issue at https://github.com/pdf/zfs_exporter/issues to have this property supported !!!
+			metricResults: `# HELP zfs_pool_unsupported !!! This property is unsupported, results are likely to be undesirable, please file an issue at https://github.com/jmcgover/zfs_exporter/issues to have this property supported !!!
 # TYPE zfs_pool_unsupported gauge
 zfs_pool_unsupported{pool="testpool"} 1024
 `,

--- a/collector/pool_test.go
+++ b/collector/pool_test.go
@@ -161,7 +161,7 @@ zfs_pool_health{pool="suspendedpool"} 6
 					`unsupported`: `1024`,
 				},
 			},
-			metricResults: `# HELP zfs_pool_unsupported !!! This property is unsupported, results are likely to be undesirable, please file an issue at https://github.com/jmcgover/zfs_exporter/issues to have this property supported !!!
+			metricResults: `# HELP zfs_pool_unsupported !!! This property is unsupported, results are likely to be undesirable, please file an issue at https://github.com/pdf/zfs_exporter/issues to have this property supported !!!
 # TYPE zfs_pool_unsupported gauge
 zfs_pool_unsupported{pool="testpool"} 1024
 `,

--- a/collector/transform.go
+++ b/collector/transform.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/pdf/zfs_exporter/v2/zfs"
+	"github.com/jmcgover/zfs_exporter/v2/zfs"
 )
 
 type poolHealthCode int

--- a/collector/zfs.go
+++ b/collector/zfs.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pdf/zfs_exporter/v2/zfs"
+	"github.com/jmcgover/zfs_exporter/v2/zfs"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/collector/zfs_test.go
+++ b/collector/zfs_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/pdf/zfs_exporter/v2/zfs/mock_zfs"
+	"github.com/jmcgover/zfs_exporter/v2/zfs/mock_zfs"
 	"go.uber.org/mock/gomock"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pdf/zfs_exporter/v2
+module github.com/jmcgover/zfs_exporter/v2
 
 go 1.24.0
 

--- a/zfs/mock_zfs/mock_zfs.go
+++ b/zfs/mock_zfs/mock_zfs.go
@@ -12,7 +12,7 @@ package mock_zfs
 import (
 	reflect "reflect"
 
-	zfs "github.com/pdf/zfs_exporter/v2/zfs"
+	zfs "github.com/jmcgover/zfs_exporter/v2/zfs"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/zfs/pool_status_json.go
+++ b/zfs/pool_status_json.go
@@ -12,7 +12,7 @@ import (
 type VdevStatusT struct {
 	Name           string                 `json:"name"`
 	VdevType       string                 `json:"vdev_type"`
-	Guid           int                    `json:"guid"`
+	Guid           int64                  `json:"guid"`
 	Path           string                 `json:"path"`
 	PhysPath       string                 `json:"phys_path"`
 	Devid          string                 `json:"devid"`
@@ -32,7 +32,7 @@ func (o VdevStatusT) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("name", o.Name),
 		slog.String("vdev_type", o.VdevType),
-		slog.Int("guid", o.Guid),
+		slog.Int64("guid", o.Guid),
 		slog.String("path", o.Path),
 		slog.String("phys_path", o.PhysPath),
 		slog.String("devid", o.Devid),
@@ -89,7 +89,7 @@ func (o ScanStatsT) LogValue() slog.Value {
 type PoolStatusT struct {
 	Name       string                 `json:"name"`
 	State      string                 `json:"state"`
-	PoolGuid   int                    `json:"pool_guid"`
+	PoolGuid   int64                  `json:"pool_guid"`
 	Txg        int                    `json:"txg"`
 	SpaVersion int                    `json:"spa_version"`
 	ZplVersion int                    `json:"zpl_version"`
@@ -104,7 +104,7 @@ func (o PoolStatusT) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("name", o.Name),
 		slog.String("state", o.State),
-		slog.Int("pool_guid", o.PoolGuid),
+		slog.Int64("pool_guid", o.PoolGuid),
 		slog.Int("txg", o.Txg),
 		slog.Int("spa_version", o.SpaVersion),
 		slog.Int("zpl_version", o.ZplVersion),

--- a/zfs/pool_status_json.go
+++ b/zfs/pool_status_json.go
@@ -10,22 +10,21 @@ import (
 )
 
 type VdevStatusT struct {
-	Name           string                 `json:"name"`
-	VdevType       string                 `json:"vdev_type"`
-	Guid           uint64                 `json:"guid"`
-	Path           string                 `json:"path"`
-	PhysPath       string                 `json:"phys_path"`
-	Devid          string                 `json:"devid"`
-	Class          string                 `json:"class"`
-	State          string                 `json:"state"`
-	Parent         string                 `json:"parent"`
-	RepDevSize     int                    `json:"rep_dev_size"`
-	PhysSpace      int                    `json:"phys_space"`
-	ReadErrors     int                    `json:"read_errors"`
-	WriteErrors    int                    `json:"write_errors"`
-	ChecksumErrors int                    `json:"checksum_errors"`
-	SlowIos        int                    `json:"slow_ios"`
-	Vdevs          map[string]VdevStatusT `json:"vdevs,omitempty"`
+	Name           string `json:"name"`
+	VdevType       string `json:"vdev_type"`
+	Guid           uint64 `json:"guid"`
+	Path           string `json:"path"`
+	PhysPath       string `json:"phys_path"`
+	Devid          string `json:"devid"`
+	Class          string `json:"class"`
+	State          string `json:"state"`
+	Parent         string `json:"parent"`
+	RepDevSize     int    `json:"rep_dev_size"`
+	PhysSpace      int    `json:"phys_space"`
+	ReadErrors     int    `json:"read_errors"`
+	WriteErrors    int    `json:"write_errors"`
+	ChecksumErrors int    `json:"checksum_errors"`
+	SlowIos        int    `json:"slow_ios"`
 }
 
 func (o VdevStatusT) LogValue() slog.Value {
@@ -45,7 +44,6 @@ func (o VdevStatusT) LogValue() slog.Value {
 		slog.Int("write_errors", o.WriteErrors),
 		slog.Int("checksum_errors", o.ChecksumErrors),
 		slog.Int("slow_ios", o.SlowIos),
-		slog.Int("num_vdevs", len(o.Vdevs)),
 	)
 }
 

--- a/zfs/pool_status_json.go
+++ b/zfs/pool_status_json.go
@@ -25,7 +25,7 @@ type VdevStatusT struct {
 	WriteErrors    int                    `json:"write_errors"`
 	ChecksumErrors int                    `json:"checksum_errors"`
 	SlowIos        int                    `json:"slow_ios"`
-	Vdevs          map[string]VdevStatusT `json:"vdevs"`
+	Vdevs          map[string]VdevStatusT `json:"vdevs,omitempty"`
 }
 
 func (o VdevStatusT) LogValue() slog.Value {

--- a/zfs/pool_status_json.go
+++ b/zfs/pool_status_json.go
@@ -20,10 +20,12 @@ type VdevStatusT struct {
 	State          string `json:"state"`
 	Parent         string `json:"parent"`
 	RepDevSize     int    `json:"rep_dev_size"`
+	SelfHealed     int    `json:"self_healed,omitempty"`
 	PhysSpace      int    `json:"phys_space"`
 	ReadErrors     int    `json:"read_errors"`
 	WriteErrors    int    `json:"write_errors"`
 	ChecksumErrors int    `json:"checksum_errors"`
+	ScanProcessed  int    `json:"scan_processed,omitempty"`
 	SlowIos        int    `json:"slow_ios"`
 }
 
@@ -39,10 +41,12 @@ func (o VdevStatusT) LogValue() slog.Value {
 		slog.String("state", o.State),
 		slog.String("parent", o.Parent),
 		slog.Int("rep_dev_size", o.RepDevSize),
+		slog.Int("self_healed", o.SelfHealed),
 		slog.Int("phys_space", o.PhysSpace),
 		slog.Int("read_errors", o.ReadErrors),
 		slog.Int("write_errors", o.WriteErrors),
 		slog.Int("checksum_errors", o.ChecksumErrors),
+		slog.Int("scan_processed", o.ScanProcessed),
 		slog.Int("slow_ios", o.SlowIos),
 	)
 }

--- a/zfs/pool_status_json.go
+++ b/zfs/pool_status_json.go
@@ -94,6 +94,7 @@ type PoolStatusT struct {
 	Status     string                 `json:"status"`
 	Action     string                 `json:"action"`
 	Moreinfo   string                 `json:"moreinfo"`
+	ErrorCount int                    `json:"error_count"`
 	ScanStats  ScanStatsT             `json:"scan_stats"`
 	Vdevs      map[string]VdevStatusT `json:"vdevs"`
 }
@@ -109,6 +110,7 @@ func (o PoolStatusT) LogValue() slog.Value {
 		slog.String("status", o.Status),
 		slog.String("action", o.Action),
 		slog.String("more_info", o.Moreinfo),
+		slog.Int("error_count", o.ErrorCount),
 		slog.Int("num_vdevs", len(o.Vdevs)),
 	)
 }

--- a/zfs/pool_status_json.go
+++ b/zfs/pool_status_json.go
@@ -1,0 +1,170 @@
+package zfs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os/exec"
+	"strings"
+)
+
+type VdevStatusT struct {
+	Name           string                 `json:"name"`
+	VdevType       string                 `json:"vdev_type"`
+	Guid           int                    `json:"guid"`
+	Path           string                 `json:"path"`
+	PhysPath       string                 `json:"phys_path"`
+	Devid          string                 `json:"devid"`
+	Class          string                 `json:"class"`
+	State          string                 `json:"state"`
+	Parent         string                 `json:"parent"`
+	RepDevSize     int                    `json:"rep_dev_size"`
+	PhysSpace      int                    `json:"phys_space"`
+	ReadErrors     int                    `json:"read_errors"`
+	WriteErrors    int                    `json:"write_errors"`
+	ChecksumErrors int                    `json:"checksum_errors"`
+	SlowIos        int                    `json:"slow_ios"`
+	Vdevs          map[string]VdevStatusT `json:"vdevs"`
+}
+
+func (o VdevStatusT) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("name", o.Name),
+		slog.String("vdev_type", o.VdevType),
+		slog.Int("guid", o.Guid),
+		slog.String("path", o.Path),
+		slog.String("phys_path", o.PhysPath),
+		slog.String("devid", o.Devid),
+		slog.String("class", o.Class),
+		slog.String("state", o.State),
+		slog.String("parent", o.Parent),
+		slog.Int("rep_dev_size", o.RepDevSize),
+		slog.Int("phys_space", o.PhysSpace),
+		slog.Int("read_errors", o.ReadErrors),
+		slog.Int("write_errors", o.WriteErrors),
+		slog.Int("checksum_errors", o.ChecksumErrors),
+		slog.Int("slow_ios", o.SlowIos),
+		slog.Int("num_vdevs", len(o.Vdevs)),
+	)
+}
+
+type ScanStatsT struct {
+	Function           string `json:"function"`
+	State              string `json:"state"`
+	StartTime          int    `json:"start_time"`
+	EndTime            int    `json:"end_time"`
+	ToExamine          int    `json:"to_examine"`
+	Examined           int    `json:"examined"`
+	Skipped            int    `json:"skipped"`
+	Processed          int    `json:"processed"`
+	Errors             int    `json:"errors"`
+	BytesPerScan       int    `json:"bytes_per_scan"`
+	PassStart          int    `json:"pass_start"`
+	ScrubPause         int    `json:"scrub_pause"`
+	ScrubSpentPaused   int    `json:"scrub_spent_paused"`
+	IssuedBytesPerScan int    `json:"issued_bytes_per_scan"`
+	Issued             int    `json:"issued"`
+}
+
+func (o ScanStatsT) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("function", o.Function),
+		slog.String("state", o.State),
+		slog.Int("start_time", o.StartTime),
+		slog.Int("end_time", o.EndTime),
+		slog.Int("to_examine", o.ToExamine),
+		slog.Int("examined", o.Examined),
+		slog.Int("skipped", o.Skipped),
+		slog.Int("processed", o.Processed),
+		slog.Int("errors", o.Errors),
+		slog.Int("BytesPerScan", o.BytesPerScan),
+		slog.Int("pass_start", o.PassStart),
+		slog.Int("scrub_pause", o.ScrubPause),
+		slog.Int("scrub_spent_paused", o.ScrubSpentPaused),
+		slog.Int("issued_bytes_per_scan", o.IssuedBytesPerScan),
+	)
+}
+
+type PoolStatusT struct {
+	Name       string                 `json:"name"`
+	State      string                 `json:"state"`
+	PoolGuid   int                    `json:"pool_guid"`
+	Txg        int                    `json:"txg"`
+	SpaVersion int                    `json:"spa_version"`
+	ZplVersion int                    `json:"zpl_version"`
+	Status     string                 `json:"status"`
+	Action     string                 `json:"action"`
+	Moreinfo   string                 `json:"moreinfo"`
+	ScanStats  ScanStatsT             `json:"scan_stats"`
+	Vdevs      map[string]VdevStatusT `json:"vdevs"`
+}
+
+func (o PoolStatusT) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("name", o.Name),
+		slog.String("state", o.State),
+		slog.Int("pool_guid", o.PoolGuid),
+		slog.Int("txg", o.Txg),
+		slog.Int("spa_version", o.SpaVersion),
+		slog.Int("zpl_version", o.ZplVersion),
+		slog.String("status", o.Status),
+		slog.String("action", o.Action),
+		slog.String("more_info", o.Moreinfo),
+		slog.Int("num_vdevs", len(o.Vdevs)),
+	)
+}
+
+type ZpoolStatusOutputT struct {
+	OutputVersion ZFSCommandOutputVersionT `json:"output_version"`
+	Pools         map[string]PoolStatusT   `json:"pools"`
+}
+
+func (o ZpoolStatusOutputT) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("output_version.command", o.OutputVersion.Command),
+		slog.Int("output_version.major", o.OutputVersion.Major),
+		slog.Int("output_version.minor", o.OutputVersion.Minor),
+		slog.Int("num_pools", len(o.Pools)),
+	)
+}
+
+func ZpoolStatusViaJSON(logger *slog.Logger) (*map[string]PoolStatusT, error) {
+	cmd := exec.Command(`zpool`, `status`, `--json`, `--json-int`)
+
+	// Setup pipes
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	// command begin
+	if err = cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start command '%s': %w", cmd.String(), err)
+	}
+
+	// stdout
+	stdo, err := io.ReadAll(stdout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read output of '%s'; output: (%w)", cmd.String(), err)
+	}
+	logger.Debug("ZFS Command Output", "stdout", stdo)
+
+	// stderr
+	stde, _ := io.ReadAll(stderr)
+	if err = cmd.Wait(); err != nil {
+		return nil, fmt.Errorf("failed to execute command '%s'; output: '%s' (%w)", cmd.String(), strings.TrimSpace(string(stde)), err)
+	}
+
+	// unmarshal JSON into Go objects
+	var o ZpoolStatusOutputT
+	if err := json.Unmarshal(stdo, &o); err != nil {
+		return nil, fmt.Errorf("failed to read output of '%s'; output: (%w)", cmd.String(), err)
+	}
+	logger.Debug("Zpool Status Output Parsed", "output", o)
+	return &o.Pools, nil
+}

--- a/zfs/pool_status_json.go
+++ b/zfs/pool_status_json.go
@@ -12,7 +12,7 @@ import (
 type VdevStatusT struct {
 	Name           string                 `json:"name"`
 	VdevType       string                 `json:"vdev_type"`
-	Guid           int64                  `json:"guid"`
+	Guid           uint64                 `json:"guid"`
 	Path           string                 `json:"path"`
 	PhysPath       string                 `json:"phys_path"`
 	Devid          string                 `json:"devid"`
@@ -32,7 +32,7 @@ func (o VdevStatusT) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("name", o.Name),
 		slog.String("vdev_type", o.VdevType),
-		slog.Int64("guid", o.Guid),
+		slog.Uint64("guid", o.Guid),
 		slog.String("path", o.Path),
 		slog.String("phys_path", o.PhysPath),
 		slog.String("devid", o.Devid),
@@ -89,7 +89,7 @@ func (o ScanStatsT) LogValue() slog.Value {
 type PoolStatusT struct {
 	Name       string                 `json:"name"`
 	State      string                 `json:"state"`
-	PoolGuid   int64                  `json:"pool_guid"`
+	PoolGuid   uint64                 `json:"pool_guid"`
 	Txg        int                    `json:"txg"`
 	SpaVersion int                    `json:"spa_version"`
 	ZplVersion int                    `json:"zpl_version"`
@@ -104,7 +104,7 @@ func (o PoolStatusT) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.String("name", o.Name),
 		slog.String("state", o.State),
-		slog.Int64("pool_guid", o.PoolGuid),
+		slog.Uint64("pool_guid", o.PoolGuid),
 		slog.Int("txg", o.Txg),
 		slog.Int("spa_version", o.SpaVersion),
 		slog.Int("zpl_version", o.ZplVersion),

--- a/zfs/version.go
+++ b/zfs/version.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os/exec"
 	"strings"
 )
@@ -24,7 +25,7 @@ type ZFSVersionOutput struct {
 	zfs_version    ZFSVersion
 }
 
-func GetZFSVersion() (*string, error) {
+func GetZFSVersion(logger *slog.Logger) (*string, error) {
 	cmd := exec.Command(`zpool`, `--json`, `--json-int`, `list`, `-Ho`, `name`)
 
 	// Setup pipes
@@ -59,5 +60,7 @@ func GetZFSVersion() (*string, error) {
 	if err := json.Unmarshal(stdo, &o); err != nil {
 		return nil, fmt.Errorf("failed to read output of '%s'; output: (%w)", cmd.String(), err)
 	}
+	logger.Debug("ZFS Command Output Version", "output_version", o.output_version)
+	logger.Debug("ZFS Version", "zfs_version", o.zfs_version)
 	return &o.zfs_version.userland, nil
 }

--- a/zfs/version.go
+++ b/zfs/version.go
@@ -24,7 +24,7 @@ type ZFSVersionOutput struct {
 	zfs_version    ZFSVersion
 }
 
-func getZFSVersion() (*ZFSVersion, error) {
+func GetZFSVersion() (*string, error) {
 	cmd := exec.Command(`zpool`, `--json`, `--json-int`, `list`, `-Ho`, `name`)
 
 	// Setup pipes
@@ -59,5 +59,5 @@ func getZFSVersion() (*ZFSVersion, error) {
 	if err := json.Unmarshal(stdo, &o); err != nil {
 		return nil, fmt.Errorf("failed to read output of '%s'; output: (%w)", cmd.String(), err)
 	}
-	return &o.zfs_version, nil
+	return &o.zfs_version.userland, nil
 }

--- a/zfs/version.go
+++ b/zfs/version.go
@@ -36,7 +36,7 @@ func (o ZFSVersionOutputT) LogValue() slog.Value {
 }
 
 func GetZFSVersion(logger *slog.Logger) (*string, error) {
-	cmd := exec.Command(`zpool`, `version`, `--json`, `--json-int`)
+	cmd := exec.Command(`zfs`, `version`, `--json`, `--json-int`)
 
 	// Setup pipes
 	stdout, err := cmd.StdoutPipe()

--- a/zfs/version.go
+++ b/zfs/version.go
@@ -10,19 +10,19 @@ import (
 )
 
 type OutputVersionT struct {
-	Command string
-	Major   int
-	Minor   int
+	Command string `json:"command"`
+	Major   int    `json:"major"`
+	Minor   int    `json:"minor"`
 }
 
 type ZFSVersionT struct {
-	Userland string
-	Kernel   string
+	Userland string `json:"userland"`
+	Kernel   string `json:"kernel"`
 }
 
 type ZFSVersionOutputT struct {
-	OutputVersion OutputVersionT
-	ZFSVersion    ZFSVersionT
+	OutputVersion OutputVersionT `json:"output_version"`
+	ZFSVersion    ZFSVersionT    `json:"zfs_version"`
 }
 
 func (o ZFSVersionOutputT) LogValue() slog.Value {
@@ -58,6 +58,7 @@ func GetZFSVersion(logger *slog.Logger) (*string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read output of '%s'; output: (%w)", cmd.String(), err)
 	}
+	logger.Debug("ZFS Command Output", "stdout", stdo)
 
 	// stderr
 	stde, _ := io.ReadAll(stderr)
@@ -70,6 +71,6 @@ func GetZFSVersion(logger *slog.Logger) (*string, error) {
 	if err := json.Unmarshal(stdo, &o); err != nil {
 		return nil, fmt.Errorf("failed to read output of '%s'; output: (%w)", cmd.String(), err)
 	}
-	logger.Debug("ZFS Command Output", "output", o)
+	logger.Debug("ZFS Command Output Parsed", "output", o)
 	return &o.ZFSVersion.Userland, nil
 }

--- a/zfs/version.go
+++ b/zfs/version.go
@@ -36,7 +36,7 @@ func (o ZFSVersionOutputT) LogValue() slog.Value {
 }
 
 func GetZFSVersion(logger *slog.Logger) (*string, error) {
-	cmd := exec.Command(`zfs`, `version`, `--json`, `--json-int`)
+	cmd := exec.Command(`zfs`, `version`, `--json`)
 
 	// Setup pipes
 	stdout, err := cmd.StdoutPipe()

--- a/zfs/version.go
+++ b/zfs/version.go
@@ -1,0 +1,63 @@
+package zfs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+type OutputVersion struct {
+	command string
+	major   int64
+	minor   int64
+}
+
+type ZFSVersion struct {
+	userland string
+	kernel   string
+}
+
+type ZFSVersionOutput struct {
+	output_version OutputVersion
+	zfs_version    ZFSVersion
+}
+
+func getZFSVersion() (*ZFSVersion, error) {
+	cmd := exec.Command(`zpool`, `--json`, `--json-int`, `list`, `-Ho`, `name`)
+
+	// Setup pipes
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	// command begin
+	if err = cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start command '%s': %w", cmd.String(), err)
+	}
+
+	// stdout
+	stdo, err := io.ReadAll(stdout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read output of '%s'; output: (%w)", cmd.String(), err)
+	}
+
+	// stderr
+	stde, _ := io.ReadAll(stderr)
+	if err = cmd.Wait(); err != nil {
+		return nil, fmt.Errorf("failed to execute command '%s'; output: '%s' (%w)", cmd.String(), strings.TrimSpace(string(stde)), err)
+	}
+
+	// unmarshal JSON into Go objects
+	var o ZFSVersionOutput
+	if err := json.Unmarshal(stdo, &o); err != nil {
+		return nil, fmt.Errorf("failed to read output of '%s'; output: (%w)", cmd.String(), err)
+	}
+	return &o.zfs_version, nil
+}

--- a/zfs/version.go
+++ b/zfs/version.go
@@ -9,20 +9,30 @@ import (
 	"strings"
 )
 
-type OutputVersion struct {
-	command string
-	major   int64
-	minor   int64
+type OutputVersionT struct {
+	Command string
+	Major   int
+	Minor   int
 }
 
-type ZFSVersion struct {
-	userland string
-	kernel   string
+type ZFSVersionT struct {
+	Userland string
+	Kernel   string
 }
 
-type ZFSVersionOutput struct {
-	output_version OutputVersion
-	zfs_version    ZFSVersion
+type ZFSVersionOutputT struct {
+	OutputVersion OutputVersionT
+	ZFSVersion    ZFSVersionT
+}
+
+func (o ZFSVersionOutputT) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("output_version.command", o.OutputVersion.Command),
+		slog.Int("output_version.major", o.OutputVersion.Major),
+		slog.Int("output_version.minor", o.OutputVersion.Minor),
+		slog.String("zfs_version.userland", o.ZFSVersion.Userland),
+		slog.String("zfs_version.kernel", o.ZFSVersion.Kernel),
+	)
 }
 
 func GetZFSVersion(logger *slog.Logger) (*string, error) {
@@ -56,11 +66,10 @@ func GetZFSVersion(logger *slog.Logger) (*string, error) {
 	}
 
 	// unmarshal JSON into Go objects
-	var o ZFSVersionOutput
+	var o ZFSVersionOutputT
 	if err := json.Unmarshal(stdo, &o); err != nil {
 		return nil, fmt.Errorf("failed to read output of '%s'; output: (%w)", cmd.String(), err)
 	}
-	logger.Debug("ZFS Command Output Version", "output_version", o.output_version)
-	logger.Debug("ZFS Version", "zfs_version", o.zfs_version)
-	return &o.zfs_version.userland, nil
+	logger.Debug("ZFS Command Output", "output", o)
+	return &o.ZFSVersion.Userland, nil
 }

--- a/zfs/version.go
+++ b/zfs/version.go
@@ -36,7 +36,7 @@ func (o ZFSVersionOutputT) LogValue() slog.Value {
 }
 
 func GetZFSVersion(logger *slog.Logger) (*string, error) {
-	cmd := exec.Command(`zpool`, `--json`, `--json-int`, `list`, `-Ho`, `name`)
+	cmd := exec.Command(`zpool`, `version`, `--json`, `--json-int`)
 
 	// Setup pipes
 	stdout, err := cmd.StdoutPipe()

--- a/zfs/version_json.go
+++ b/zfs/version_json.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-type OutputVersionT struct {
+type ZFSCommandOutputVersionT struct {
 	Command string `json:"command"`
 	Major   int    `json:"major"`
 	Minor   int    `json:"minor"`
@@ -21,8 +21,8 @@ type ZFSVersionT struct {
 }
 
 type ZFSVersionOutputT struct {
-	OutputVersion OutputVersionT `json:"output_version"`
-	ZFSVersion    ZFSVersionT    `json:"zfs_version"`
+	OutputVersion ZFSCommandOutputVersionT `json:"output_version"`
+	ZFSVersion    ZFSVersionT              `json:"zfs_version"`
 }
 
 func (o ZFSVersionOutputT) LogValue() slog.Value {
@@ -35,7 +35,7 @@ func (o ZFSVersionOutputT) LogValue() slog.Value {
 	)
 }
 
-func GetZFSVersion(logger *slog.Logger) (*string, error) {
+func GetZFSVersionViaJSON(logger *slog.Logger) (*string, error) {
 	cmd := exec.Command(`zfs`, `version`, `--json`)
 
 	// Setup pipes

--- a/zfs/version_json.go
+++ b/zfs/version_json.go
@@ -15,6 +15,14 @@ type ZFSCommandOutputVersionT struct {
 	Minor   int    `json:"minor"`
 }
 
+func (o ZFSCommandOutputVersionT) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("command", o.Command),
+		slog.Int("major", o.Major),
+		slog.Int("minor", o.Minor),
+	)
+}
+
 type ZFSVersionT struct {
 	Userland string `json:"userland"`
 	Kernel   string `json:"kernel"`

--- a/zfs_exporter.go
+++ b/zfs_exporter.go
@@ -56,9 +56,14 @@ func main() {
 	}
 	logger.Debug("Num Pools", "num_pools", len(*pool_name_status_map))
 	for pool_name, pool_status := range *pool_name_status_map {
-		logger.Debug("Pool Status", "name", pool_name, "status", pool_status, "scan_stats", pool_status.ScanStats, "num_vdevs", len(pool_status.Vdevs))
+		logger.Debug("Pool Name", "name", pool_name)
+		logger.Debug("Pool Vdevs", "num_vdevs", len(pool_status.Vdevs))
+		logger.Debug("Pool Status", "status", pool_status)
+		logger.Debug("Pool ScanStats", "scan_stats", pool_status.ScanStats)
 		for vdev_name, vdev_status := range pool_status.Vdevs {
-			logger.Debug("Vdev Status", "name", vdev_name, "status", vdev_status, "num_vdevs", len(vdev_status.Vdevs))
+			logger.Debug("Vdev Name", "name", vdev_name)
+			logger.Debug("Vdev Vdevs", "num_vdevs", len(vdev_status.Vdevs))
+			logger.Debug("Vdev Status", "status", vdev_status)
 		}
 	}
 

--- a/zfs_exporter.go
+++ b/zfs_exporter.go
@@ -40,6 +40,13 @@ func main() {
 	logger.Info("Starting zfs_exporter", "version", version.Info())
 	logger.Info("Build context", "context", version.BuildContext())
 
+	zfs_version, err := zfs.GetZFSVersion()
+	if err != nil {
+		logger.Error("Error getting ZFS version", "err", err)
+		os.Exit(7)
+	}
+	logger.Info("ZFS Version", "version", zfs_version)
+
 	c, err := collector.NewZFS(collector.ZFSConfig{
 		DisableMetrics: *metricsExporterDisabled,
 		Deadline:       *deadline,

--- a/zfs_exporter.go
+++ b/zfs_exporter.go
@@ -40,7 +40,7 @@ func main() {
 	logger.Info("Starting zfs_exporter", "version", version.Info())
 	logger.Info("Build context", "context", version.BuildContext())
 
-	zfs_version, err := zfs.GetZFSVersion()
+	zfs_version, err := zfs.GetZFSVersion(logger)
 	if err != nil {
 		logger.Error("Error getting ZFS version", "err", err)
 		os.Exit(7)

--- a/zfs_exporter.go
+++ b/zfs_exporter.go
@@ -62,7 +62,6 @@ func main() {
 		logger.Debug("Pool ScanStats", "scan_stats", pool_status.ScanStats)
 		for vdev_name, vdev_status := range pool_status.Vdevs {
 			logger.Debug("Vdev Name", "name", vdev_name)
-			logger.Debug("Vdev Vdevs", "num_vdevs", len(vdev_status.Vdevs))
 			logger.Debug("Vdev Status", "status", vdev_status)
 		}
 	}

--- a/zfs_exporter.go
+++ b/zfs_exporter.go
@@ -40,7 +40,7 @@ func main() {
 	logger.Info("Starting zfs_exporter", "version", version.Info())
 	logger.Info("Build context", "context", version.BuildContext())
 
-	zfs_version, err := zfs.GetZFSVersion(logger)
+	zfs_version, err := zfs.GetZFSVersionViaJSON(logger)
 	if err != nil {
 		logger.Error("Error getting ZFS version", "err", err)
 		os.Exit(7)

--- a/zfs_exporter.go
+++ b/zfs_exporter.go
@@ -45,7 +45,7 @@ func main() {
 		logger.Error("Error getting ZFS version", "err", err)
 		os.Exit(7)
 	}
-	logger.Info("ZFS Version", "version", zfs_version)
+	logger.Info("ZFS Version", "version", *zfs_version)
 
 	c, err := collector.NewZFS(collector.ZFSConfig{
 		DisableMetrics: *metricsExporterDisabled,

--- a/zfs_exporter.go
+++ b/zfs_exporter.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pdf/zfs_exporter/v2/collector"
-	"github.com/pdf/zfs_exporter/v2/zfs"
+	"github.com/jmcgover/zfs_exporter/v2/collector"
+	"github.com/jmcgover/zfs_exporter/v2/zfs"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"


### PR DESCRIPTION
# TL;DR
- [openzfs/zfs #16217](https://github.com/openzfs/zfs/pull/16217) introduced JSON output flags for the following commands:
  - `zfs {list,get,mount,version}`
  - `zpool {status,list,get,version}`
- parse json output of two ZFS CLI commands:
  - `zfs version --json`
  - `zpool status --json --json-int --json-flat-vdevs`
- proof of concept to see how easy/difficult it is to parse JSON in `go`

# TODO
- [ ] Check for typos and field coverage
- [ ] Determination, at startup, of `--json*` support in `zfs`/`zpool` commands
- [ ] Create a separate JSON implementation of the collectors

# Example

```bash
$ ./zfs_exporter --log.level=debug
time=2026-01-11T23:23:26.560-08:00 level=INFO source=zfs_exporter.go:40 msg="Starting zfs_exporter" version="(version=2.3.11, branch=master, revision=eabb9785acd2679940fc3c2ada649865359b6c7d)"
time=2026-01-11T23:23:26.560-08:00 level=INFO source=zfs_exporter.go:41 msg="Build context" context="(go=go1.25.5 X:nodwarf5, platform=linux/amd64, user=paul@trunks, date=20260112-07:18:02, tags=netgo)"
time=2026-01-11T23:23:26.565-08:00 level=DEBUG source=version_json.go:69 msg="ZFS Command Output" stdout="{\"output_version\":{\"command\":\"zfs version\",\"vers_major\":0,\"vers_minor\":1},\"zfs_version\":{\"userland\":\"zfs-2.4.0-1\",\"kernel\":\"zfs-kmod-2.4.0-1\"}}\n"
time=2026-01-11T23:23:26.566-08:00 level=DEBUG source=version_json.go:82 msg="ZFS Command Output Parsed" output.output_version.command="zfs version" output.output_version.major=0 output.output_version.minor=0 output.zfs_version.userland=zfs-2.4.0-1 output.zfs_version.kernel=zfs-kmod-2.4.0-1
time=2026-01-11T23:23:26.566-08:00 level=INFO source=zfs_exporter.go:49 msg="ZFS Version" version=zfs-2.4.0-1
time=2026-01-11T23:23:26.579-08:00 level=DEBUG source=pool_status_json.go:155 msg="ZFS Command Output" stdout="{\"output_version\":{\"command\":\"zpool status\",\"vers_major\":0,\"vers_minor\":1},\"pools\":{\"greenwood\":{\"name\":\"greenwood\",\"state\":\"ONLINE\",\"pool_guid\":240630935905734902,\"txg\":60298799,\"spa_version\":5000,\"zpl_version\":5,\"status\":\"One or more devices has experienced an unrecoverable error.  An\\n\\tattempt was made to correct the error.  Applications are unaffected.\\n\",\"action\":\"Determine if the device needs to be replaced, and clear the errors\\n\\tusing 'zpool clear' or replace the device with 'zpool replace'.\\n\",\"msgid\":\"ZFS-8000-9P\",\"moreinfo\":\"https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-9P\",\"scan_stats\":{\"function\":\"SCRUB\",\"state\":\"FINISHED\",\"start_time\":1767782105,\"end_time\":1767829343,\"to_examine\":42025429180416,\"examined\":42018061897728,\"skipped\":14696448,\"processed\":983040,\"errors\":0,\"bytes_per_scan\":0,\"pass_start\":1767818537,\"scrub_pause\":0,\"scrub_spent_paused\":0,\"issued_bytes_per_scan\":8485179076608,\"issued\":42018036584448},\"vdevs\":{\"greenwood\":{\"name\":\"greenwood\",\"vdev_type\":\"root\",\"guid\":240630935905734902,\"class\":\"normal\",\"state\":\"ONLINE\",\"alloc_space\":42037227356160,\"total_space\":63771674411008,\"def_space\":52312701665280,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"vdevs\":{\"raidz2-0\":{\"name\":\"raidz2-0\",\"vdev_type\":\"raidz\",\"guid\":8276276583640132761,\"class\":\"normal\",\"state\":\"ONLINE\",\"alloc_space\":42037227356160,\"total_space\":63771674411008,\"def_space\":52312701665280,\"rep_dev_size\":63771674411008,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"vdevs\":{\"redwood\":{\"name\":\"redwood\",\"vdev_type\":\"disk\",\"guid\":1693533752164838511,\"path\":\"/dev/disk/by-vdev/redwood-part1\",\"phys_path\":\"pci-0000:01:00.0-sas-phy7-lun-0\",\"devid\":\"ata-WDC_WD40EFZX-68AWUN0_WD-WX12DA0R1JNC-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"maple\":{\"name\":\"maple\",\"vdev_type\":\"disk\",\"guid\":13069515523376549602,\"path\":\"/dev/disk/by-vdev/maple-part1\",\"phys_path\":\"pci-0000:01:00.0-sas-phy6-lun-0\",\"devid\":\"ata-WDC_WD40EFPX-68C6CN0_WD-WX62D15PLTV8-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"beech\":{\"name\":\"beech\",\"vdev_type\":\"disk\",\"guid\":10338606211899637945,\"path\":\"/dev/disk/by-vdev/beech-part1\",\"phys_path\":\"pci-0000:01:00.0-sas-phy1-lun-0\",\"devid\":\"ata-ST4000DM000-1F2168_Z3076EQT-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"willow\":{\"name\":\"willow\",\"vdev_type\":\"disk\",\"guid\":17747722603856524209,\"path\":\"/dev/disk/by-vdev/willow-part1\",\"phys_path\":\"pci-0000:01:00.0-sas-phy0-lun-0\",\"devid\":\"ata-ST4000DM000-1F2168_Z307H0QR-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"birch\":{\"name\":\"birch\",\"vdev_type\":\"disk\",\"guid\":10432169852342298766,\"path\":\"/dev/disk/by-vdev/birch-part1\",\"phys_path\":\"pci-0000:01:00.0-sas-phy3-lun-0\",\"devid\":\"ata-ST4000DM000-1F2168_Z307FDNV-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"oak\":{\"name\":\"oak\",\"vdev_type\":\"disk\",\"guid\":5598510555668390460,\"path\":\"/dev/disk/by-vdev/oak-part1\",\"phys_path\":\"pci-0000:01:00.0-sas-phy2-lun-0\",\"devid\":\"ata-ST4000DM000-1F2168_Z307E12J-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"walnut\":{\"name\":\"walnut\",\"vdev_type\":\"disk\",\"guid\":5052862979346025662,\"path\":\"/dev/disk/by-vdev/walnut-part1\",\"phys_path\":\"pci-0000:02:00.0-sas-phy1-lun-0\",\"devid\":\"ata-ST4000DM000-2AE166_WDH02AEY-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"pine\":{\"name\":\"pine\",\"vdev_type\":\"disk\",\"guid\":11194587813252383021,\"path\":\"/dev/disk/by-vdev/pine-part1\",\"phys_path\":\"pci-0000:01:00.0-sas-phy5-lun-0\",\"devid\":\"ata-ST4000DM000-1F2168_Z30620SR-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"sycamore\":{\"name\":\"sycamore\",\"vdev_type\":\"disk\",\"guid\":17046160168366816094,\"path\":\"/dev/disk/by-vdev/sycamore-part1\",\"phys_path\":\"pci-0000:01:00.0-sas-phy4-lun-0\",\"devid\":\"ata-HGST_HUS724040ALE640_PK1331PAKP6G9S-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"palm\":{\"name\":\"palm\",\"vdev_type\":\"disk\",\"guid\":3462721303918148450,\"path\":\"/dev/disk/by-vdev/palm-part1\",\"phys_path\":\"pci-0000:02:00.0-sas-phy2-lun-0\",\"devid\":\"ata-ST4000DM000-2AE166_WDH02KMA-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"gum\":{\"name\":\"gum\",\"vdev_type\":\"disk\",\"guid\":17480034178652514697,\"path\":\"/dev/disk/by-vdev/gum-part1\",\"phys_path\":\"pci-0000:02:00.0-sas-phy3-lun-0\",\"devid\":\"ata-HGST_HUS724040ALE640_PK1334PAKSAD5S-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"poplar\":{\"name\":\"poplar\",\"vdev_type\":\"disk\",\"guid\":3990993109261751504,\"path\":\"/dev/disk/by-vdev/poplar-part1\",\"phys_path\":\"pci-0000:02:00.0-sas-phy3-lun-0\",\"devid\":\"ata-ST4000DM000-2AE166_WDH02KXB-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"dogwood\":{\"name\":\"dogwood\",\"vdev_type\":\"disk\",\"guid\":13434953024622563852,\"path\":\"/dev/disk/by-vdev/dogwood-part1\",\"phys_path\":\"pci-0000:00:1f.2-ata-5\",\"devid\":\"ata-WDC_WD40EFZX-68AWUN0_WD-WX12DA0EAAVZ-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"ash\":{\"name\":\"ash\",\"vdev_type\":\"disk\",\"guid\":13908182941863625816,\"path\":\"/dev/disk/by-vdev/ash-part1\",\"phys_path\":\"pci-0000:02:00.0-sas-phy4-lun-0\",\"devid\":\"ata-WDC_WD40EZRX-00SPEB0_WD-WCC4E1SU6T3L-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"self_healed\":3928064,\"phys_space\":4000776716288,\"read_errors\":56,\"write_errors\":0,\"checksum_errors\":0,\"scan_processed\":983040,\"slow_ios\":44},\"alder\":{\"name\":\"alder\",\"vdev_type\":\"disk\",\"guid\":3898698817971933339,\"path\":\"/dev/disk/by-vdev/alder-part1\",\"phys_path\":\"pci-0000:02:00.0-sas-phy6-lun-0\",\"devid\":\"ata-WDC_WD40EZRX-00SPEB0_WD-WCC4E6XYD58S-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0},\"linden\":{\"name\":\"linden\",\"vdev_type\":\"disk\",\"guid\":16738412563713742014,\"path\":\"/dev/disk/by-vdev/linden-part1\",\"phys_path\":\"pci-0000:02:00.0-sas-phy7-lun-0\",\"devid\":\"ata-WDC_WD40EZRX-00SPEB0_WD-WCC4E2UCCERP-part1\",\"class\":\"normal\",\"state\":\"ONLINE\",\"rep_dev_size\":3985734369280,\"phys_space\":4000776716288,\"read_errors\":0,\"write_errors\":0,\"checksum_errors\":0,\"slow_ios\":0}}}}}},\"error_count\":0}}}\n"
time=2026-01-11T23:23:26.580-08:00 level=DEBUG source=pool_status_json.go:168 msg="Zpool Status Output Parsed" output.output_version.command="zpool status" output.output_version.major=0 output.output_version.minor=0 output.num_pools=1
time=2026-01-11T23:23:26.580-08:00 level=DEBUG source=zfs_exporter.go:57 msg="Num Pools" num_pools=1
time=2026-01-11T23:23:26.580-08:00 level=DEBUG source=zfs_exporter.go:59 msg="Pool Status" name=greenwood status.name=greenwood status.state=ONLINE status.pool_guid=240630935905734902 status.txg=60298799 status.spa_version=5000 status.zpl_version=5 status.status="One or more devices has experienced an unrecoverable error.  An\n\tattempt was made to correct the error.  Applications are unaffected.\n" status.action="Determine if the device needs to be replaced, and clear the errors\n\tusing 'zpool clear' or replace the device with 'zpool replace'.\n" status.more_info=https://openzfs.github.io/openzfs-docs/msg/ZFS-8000-9P status.num_vdevs=1 scan_stats.function=SCRUB scan_stats.state=FINISHED scan_stats.start_time=1767782105 scan_stats.end_time=1767829343 scan_stats.to_examine=42025429180416 scan_stats.examined=42018061897728 scan_stats.skipped=14696448 scan_stats.processed=983040 scan_stats.errors=0 scan_stats.BytesPerScan=0 scan_stats.pass_start=1767818537 scan_stats.scrub_pause=0 scan_stats.scrub_spent_paused=0 scan_stats.issued_bytes_per_scan=8485179076608 num_vdevs=1
time=2026-01-11T23:23:26.580-08:00 level=DEBUG source=zfs_exporter.go:61 msg="Vdev Status" name=greenwood status.name=greenwood status.vdev_type=root status.guid=240630935905734902 status.path="" status.phys_path="" status.devid="" status.class=normal status.state=ONLINE status.parent="" status.rep_dev_size=0 status.phys_space=0 status.read_errors=0 status.write_errors=0 status.checksum_errors=0 status.slow_ios=0 status.num_vdevs=1 num_vdevs=1
time=2026-01-11T23:23:26.580-08:00 level=INFO source=zfs_exporter.go:89 msg="Enabling pools" pools=(all)
time=2026-01-11T23:23:26.581-08:00 level=INFO source=zfs_exporter.go:98 msg="Enabling collectors" collectors="pool, dataset-filesystem, dataset-volume"
time=2026-01-11T23:23:26.581-08:00 level=ERROR source=zfs_exporter.go:124 msg="Error starting HTTP server" err="listen tcp :9134: bind: address already in use"
```