### PR TITLE
Update installation command for zfs_exporter to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Installation can also be accomplished using `go install`:
 
 ```bash
 version=latest # or a specific version tag
-go install github.com/pdf/zfs_exporter@$version
+go install github.com/pdf/zfs_exporter/v2@$version
 ```
 
 ## Usage


### PR DESCRIPTION
Includes the "/v2" postfix to correctly target later versions of the zfs_exporter