### PR TITLE
fix(collector): handle keystatus=-

### DIFF
--- a/collector/transform.go
+++ b/collector/transform.go
@@ -61,6 +61,8 @@ func transformHealthCode(status string) (float64, error) {
 func transformKeystatus(status string) (float64, error) {
 	var result keystatusCode
 	switch zfs.Keystatus(status) {
+	case `-`:
+		fallthrough
 	case zfs.KeystatusNone:
 		result = keystatusNone
 	case zfs.KeystatusAvailable:


### PR DESCRIPTION
turns out that even though `keystatus` is documented to have the value `none` for unencrypted datasets, `zfs list` and `zfs get` display it as `-`.

fixes the following error when collecting keystatus:

	{"time":"2026-08-10T13:18:46.191309066Z","level":"ERROR","source":"zfs.go:217","msg":"Executing collector","status":"error","collector":"dataset-filesystem","durationSeconds":0.014250391,"err":"unknown keystatus: -"}

Fixes: 850c4359beb7dc1492b881daa1831d507832bd10